### PR TITLE
add optional options to S3 storage options

### DIFF
--- a/src/storage/s3.ts
+++ b/src/storage/s3.ts
@@ -5,6 +5,11 @@ import mime from "mime";
 import { logger } from "../logger.js";
 import { IBlobStorage } from "./interface.js";
 
+export interface S3StorageOptions {
+  region?: string;
+  useSSL?: boolean;
+};
+
 export class S3Storage implements IBlobStorage {
   log = logger.extend("storage:s3");
   client: Client;
@@ -19,11 +24,14 @@ export class S3Storage implements IBlobStorage {
     accessKey: string,
     secretKey: string,
     bucket: string,
+    options?: S3StorageOptions,
   ) {
     this.client = new Client({
       endPoint: endpoint,
       accessKey: accessKey,
       secretKey: secretKey,
+      region: options?.region,
+      useSSL: options?.useSSL,
     });
 
     this.bucket = bucket;


### PR DESCRIPTION
I was trying to setup a blossom server using blossom server and an R2 bucket, but kept getting errors.

This PR allows setting a couple more parameters in the S3 connection setup to help support more usecases.

`useSSL` is useful when running locally for dev purposes and talking to a docker minio container.
`region` is needed for R2. Even though their docs say they alias `us-east-1` to `auto`, it didn't seem to work for me. I had to set it to `auto` to connect properly.

I tested it out with `blossom-server` and can put a PR up there to allow these config options.